### PR TITLE
feat: add trailing slash configuration option for route generation

### DIFF
--- a/.changeset/seven-crabs-mate.md
+++ b/.changeset/seven-crabs-mate.md
@@ -1,0 +1,5 @@
+---
+"@safe-routes/nextjs": patch
+---
+
+feat: add trailing slash configuration option for route generation

--- a/apps/example/.safe-routes/index.ts
+++ b/apps/example/.safe-routes/index.ts
@@ -29,7 +29,7 @@ const buildSearchParams = (params?: SearchParams): string => {
   return `?${searchParams.toString()}`;
 };
 
-export type SafeRoutePath = "/login" | "/blog/[slug]/[hoge]" | "/blog/[slug]" | "/" | "/products/[[...filters]]" | "/products" | "/shop/[...categories]" | "/shop" | "/users/[user_id]/[year]/[month]" | "/users/[user_id]" | "/users/[user_id]/posts/[post-id]" | "/about" | "/docs/[...slug]" | "/video/[[...name]]" | "/video" | "/video/[id]";;
+export type SafeRoutePath = "/login/" | "/blog/[slug]/[hoge]/" | "/blog/[slug]/" | "/" | "/products/[[...filters]]/" | "/products/" | "/shop/[...categories]/" | "/shop/" | "/users/[user_id]/[year]/[month]/" | "/users/[user_id]/" | "/users/[user_id]/posts/[post-id]/" | "/about/" | "/docs/[...slug]/" | "/video/[[...name]]/" | "/video/" | "/video/[id]/";;
 
 export type SafeRouteParams<T extends SafeRoutePath> = (typeof safeRoutes)[T]['params'];
 export type SafeRouteSearchParams<T extends SafeRoutePath> = (typeof safeRoutes)[T]['searchParams'];
@@ -90,17 +90,17 @@ export function safeRoute<T extends SafeRoutePath>(
 }
 
 export const safeRoutes = {
-"/login": {
+"/login/": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../app/(auth)/login/page.tsx").SearchParams
 },
-"/blog/[slug]/[hoge]": {
+"/blog/[slug]/[hoge]/": {
   params: {} as { slug: string | number, hoge: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/blog/[slug]/[hoge]/page.tsx").SearchParams
 },
-"/blog/[slug]": {
+"/blog/[slug]/": {
   params: {} as { slug: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/blog/[slug]/page.tsx").SearchParams
@@ -110,62 +110,62 @@ export const safeRoutes = {
   // @ts-ignore
   searchParams: {} as import("../app/page.tsx").SearchParams
 },
-"/products": {
+"/products/": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../app/products/[[...filters]]/page.tsx").SearchParams
 },
-"/products/[[...filters]]": {
+"/products/[[...filters]]/": {
   params: {} as { filters: string[] | number[] },
   // @ts-ignore
   searchParams: {} as import("../app/products/[[...filters]]/page.tsx").SearchParams
 },
-"/shop/[...categories]": {
+"/shop/[...categories]/": {
   params: {} as { categories: string[] | number[] },
   // @ts-ignore
   searchParams: {} as import("../app/shop/[...categories]/page.tsx").SearchParams
 },
-"/shop": {
+"/shop/": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../app/shop/page.tsx").SearchParams
 },
-"/users/[user_id]/[year]/[month]": {
+"/users/[user_id]/[year]/[month]/": {
   params: {} as { userId: string | number, year: string | number, month: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/users/[user_id]/[year]/[month]/page.tsx").SearchParams
 },
-"/users/[user_id]": {
+"/users/[user_id]/": {
   params: {} as { userId: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/users/[user_id]/page.tsx").SearchParams
 },
-"/users/[user_id]/posts/[post-id]": {
+"/users/[user_id]/posts/[post-id]/": {
   params: {} as { userId: string | number, postId: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/users/[user_id]/posts/[post-id]/page.tsx").SearchParams
 },
-"/about": {
+"/about/": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../pages/about.tsx").SearchParams
 },
-"/docs/[...slug]": {
+"/docs/[...slug]/": {
   params: {} as { slug: string[] | number[] },
   // @ts-ignore
   searchParams: {} as import("../pages/docs/[...slug].tsx").SearchParams
 },
-"/video": {
+"/video/": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../pages/video/[[...name]].tsx").SearchParams
 },
-"/video/[[...name]]": {
+"/video/[[...name]]/": {
   params: {} as { name: string[] | number[] },
   // @ts-ignore
   searchParams: {} as import("../pages/video/[[...name]].tsx").SearchParams
 },
-"/video/[id]": {
+"/video/[id]/": {
   params: {} as { id: string | number },
   // @ts-ignore
   searchParams: {} as import("../pages/video/[id]/index.tsx").SearchParams

--- a/apps/example/.safe-routes/index.ts
+++ b/apps/example/.safe-routes/index.ts
@@ -29,7 +29,7 @@ const buildSearchParams = (params?: SearchParams): string => {
   return `?${searchParams.toString()}`;
 };
 
-export type SafeRoutePath = "/login/" | "/blog/[slug]/[hoge]/" | "/blog/[slug]/" | "/" | "/products/[[...filters]]/" | "/products/" | "/shop/[...categories]/" | "/shop/" | "/users/[user_id]/[year]/[month]/" | "/users/[user_id]/" | "/users/[user_id]/posts/[post-id]/" | "/about/" | "/docs/[...slug]/" | "/video/[[...name]]/" | "/video/" | "/video/[id]/";;
+export type SafeRoutePath = "/login" | "/blog/[slug]/[hoge]" | "/blog/[slug]" | "/" | "/products/[[...filters]]" | "/products" | "/shop/[...categories]" | "/shop" | "/users/[user_id]/[year]/[month]" | "/users/[user_id]" | "/users/[user_id]/posts/[post-id]" | "/about" | "/docs/[...slug]" | "/video/[[...name]]" | "/video" | "/video/[id]";;
 
 export type SafeRouteParams<T extends SafeRoutePath> = (typeof safeRoutes)[T]['params'];
 export type SafeRouteSearchParams<T extends SafeRoutePath> = (typeof safeRoutes)[T]['searchParams'];
@@ -90,17 +90,17 @@ export function safeRoute<T extends SafeRoutePath>(
 }
 
 export const safeRoutes = {
-"/login/": {
+"/login": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../app/(auth)/login/page.tsx").SearchParams
 },
-"/blog/[slug]/[hoge]/": {
+"/blog/[slug]/[hoge]": {
   params: {} as { slug: string | number, hoge: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/blog/[slug]/[hoge]/page.tsx").SearchParams
 },
-"/blog/[slug]/": {
+"/blog/[slug]": {
   params: {} as { slug: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/blog/[slug]/page.tsx").SearchParams
@@ -110,62 +110,62 @@ export const safeRoutes = {
   // @ts-ignore
   searchParams: {} as import("../app/page.tsx").SearchParams
 },
-"/products/": {
+"/products": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../app/products/[[...filters]]/page.tsx").SearchParams
 },
-"/products/[[...filters]]/": {
+"/products/[[...filters]]": {
   params: {} as { filters: string[] | number[] },
   // @ts-ignore
   searchParams: {} as import("../app/products/[[...filters]]/page.tsx").SearchParams
 },
-"/shop/[...categories]/": {
+"/shop/[...categories]": {
   params: {} as { categories: string[] | number[] },
   // @ts-ignore
   searchParams: {} as import("../app/shop/[...categories]/page.tsx").SearchParams
 },
-"/shop/": {
+"/shop": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../app/shop/page.tsx").SearchParams
 },
-"/users/[user_id]/[year]/[month]/": {
+"/users/[user_id]/[year]/[month]": {
   params: {} as { userId: string | number, year: string | number, month: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/users/[user_id]/[year]/[month]/page.tsx").SearchParams
 },
-"/users/[user_id]/": {
+"/users/[user_id]": {
   params: {} as { userId: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/users/[user_id]/page.tsx").SearchParams
 },
-"/users/[user_id]/posts/[post-id]/": {
+"/users/[user_id]/posts/[post-id]": {
   params: {} as { userId: string | number, postId: string | number },
   // @ts-ignore
   searchParams: {} as import("../app/users/[user_id]/posts/[post-id]/page.tsx").SearchParams
 },
-"/about/": {
+"/about": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../pages/about.tsx").SearchParams
 },
-"/docs/[...slug]/": {
+"/docs/[...slug]": {
   params: {} as { slug: string[] | number[] },
   // @ts-ignore
   searchParams: {} as import("../pages/docs/[...slug].tsx").SearchParams
 },
-"/video/": {
+"/video": {
   params: {} as Record<string, never>,
   // @ts-ignore
   searchParams: {} as import("../pages/video/[[...name]].tsx").SearchParams
 },
-"/video/[[...name]]/": {
+"/video/[[...name]]": {
   params: {} as { name: string[] | number[] },
   // @ts-ignore
   searchParams: {} as import("../pages/video/[[...name]].tsx").SearchParams
 },
-"/video/[id]/": {
+"/video/[id]": {
   params: {} as { id: string | number },
   // @ts-ignore
   searchParams: {} as import("../pages/video/[id]/index.tsx").SearchParams

--- a/apps/example/app/page.tsx
+++ b/apps/example/app/page.tsx
@@ -8,20 +8,20 @@ export type SearchParams = {
 
 export default function HomePage() {
   const userId = safeRoute(
-    "/users/[user-id]/",
+    "/users/[user_id]",
     { userId: 1 },
     { page: 1, sort: "desc" },
   );
   safeRoute(
-    "/products/[[...filters]]/",
+    "/products/[[...filters]]",
     { filters: ["sort", "page"] },
     { sort: 'asc', page: 1},
   );
-  safeRoute('/products/', { sort: 'asc', page: 1});
-  safeRoute('/', { page: 1});
-  safeRoute("/users/[user-id]/", { userId: 1 }, { page: 1});
-  safeRoute("/shop/", { isRequired: true, isOptional: 1 });
-  safeRoute('/login/', { redirect: "https://example.com" });
+  safeRoute('/products', { sort: 'asc', page: 1});
+  safeRoute('/', { page: 1}),
+  safeRoute("/users/[user-id]", { userId: 1 }, { page: 1});
+  safeRoute("/shop", { isRequired: true, isOptional: 1 });
+  safeRoute('/login', { redirect: "https://example.com" });
 
   return (
     <div>

--- a/apps/example/app/page.tsx
+++ b/apps/example/app/page.tsx
@@ -18,8 +18,7 @@ export default function HomePage() {
     { sort: 'asc', page: 1},
   );
   safeRoute('/products', { sort: 'asc', page: 1});
-  safeRoute('/', { page: 1}),
-  safeRoute("/users/[user-id]", { userId: 1 }, { page: 1});
+  safeRoute('/', { page: 1});
   safeRoute("/shop", { isRequired: true, isOptional: 1 });
   safeRoute('/login', { redirect: "https://example.com" });
 
@@ -28,13 +27,13 @@ export default function HomePage() {
       <h1>Route Examples</h1>
       <ul>
         <li>
-          <Link href={safeRoute("/blog/[slug]/", { slug: "hello" }, { page: 1})}>
+          <Link href={safeRoute("/blog/[slug]", { slug: "hello" }, { page: 1})}>
             Dynamic Route
           </Link>
         </li>
         <li>
           <Link
-            href={safeRoute("/shop/[...categories]/", { categories: ["men", "shoes"] }, { page: 1})}
+            href={safeRoute("/shop/[...categories]", { categories: ["men", "shoes"] }, { page: 1})}
           >
             Catch-all Route
           </Link>
@@ -42,7 +41,7 @@ export default function HomePage() {
         <li>
           <Link
             href={safeRoute(
-              "/products/",
+              "/products",
               { sort: "asc", page: 1 }
             )}
           >
@@ -51,10 +50,7 @@ export default function HomePage() {
         </li>
         <li>
           <Link
-            href={safeRoute("/users/[user-id]/posts/[post-id]/", {
-              userId: "123",
-              postId: "11",
-            }, { page: 1})}
+            href={safeRoute("/users/[user_id]/posts/[post-id]", { userId: "123", postId: "11" }, { page: 1 })}
           >
             Multiple Dynamic Segments
           </Link>

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "npm run dev:safe-routes & npm run dev:next",
     "dev:next": "next dev",
-    "dev:safe-routes": "safe-routes --watch --no-trailing-slash",
+    "dev:safe-routes": "safe-routes --watch --trailing-slash false",
     "build": "safe-routes && next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "npm run dev:safe-routes & npm run dev:next",
     "dev:next": "next dev",
-    "dev:safe-routes": "safe-routes --watch",
+    "dev:safe-routes": "safe-routes --watch --no-trailing-slash",
     "build": "safe-routes && next build",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -32,7 +32,7 @@ yarn add @safe-routes/nextjs --dev
 # or
 pnpm add @safe-routes/nextjs --dev
 # or
-npx @safe-routes/nextjs --no-trailing-slash
+npx @safe-routes/nextjs
 ```
 
 ## Setup
@@ -84,6 +84,7 @@ Usage: safe-routes [options]
 Options:
   -w, --watch            Watch for file changes and regenerate types
   -o, --out-dir <path>  Output directory (default: .safe-routes)
+  -t, --trailing-slash true | false  Enable trailing slash in generated routes (default: true)
   -h, --help           Display help for command
 ```
 

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -31,6 +31,8 @@ npm install @safe-routes/nextjs --save-dev
 yarn add @safe-routes/nextjs --dev
 # or
 pnpm add @safe-routes/nextjs --dev
+# or
+npx @safe-routes/nextjs --no-trailing-slash
 ```
 
 ## Setup

--- a/packages/nextjs/src/cli.ts
+++ b/packages/nextjs/src/cli.ts
@@ -41,13 +41,7 @@ program
       },
     };
 
-    console.log('config', config);
-
-    const generate = async () => {
-      return await generateTypes(config);
-    };
-
-    await generate();
+    await generateTypes(config);
 
     if (options.watch) {
       const targetDirs = [appDir, pagesDir].filter((dir) => dir);

--- a/packages/nextjs/src/cli.ts
+++ b/packages/nextjs/src/cli.ts
@@ -62,7 +62,6 @@ program
 
       watcher
         .on("all", async () => {
-          console.log("Generating types... by @safe-routes/nextjs");
           await generateTypes({ appDir, pagesDir, config: { trailingSlash, outDir } })
         })
     }

--- a/packages/nextjs/src/cli.ts
+++ b/packages/nextjs/src/cli.ts
@@ -12,7 +12,7 @@ program
   .description("Generate type-safe routes for Next.js")
   .option("-w, --watch", "Watch for file changes and regenerate types")
   .option("-o, --out-dir <path>", "Output directory (default: .safe-routes)")
-  .option("--no-trailing-slash", "Disable trailing slash in generated routes (default: true)")
+  .option("--no-trailing-slash", "Disable trailing slash in generated routes")
   .action(async (options: UserConfig) => {
 
     const findDirectory = (baseName: string): string | null => {

--- a/packages/nextjs/src/cli.ts
+++ b/packages/nextjs/src/cli.ts
@@ -25,7 +25,7 @@ program
 
     const appDir = findDirectory("app") || "";
     const pagesDir = findDirectory("pages") || "";
-    const trailingSlash = !options.trailingSlash;
+    const trailingSlash = !!options.trailingSlash;
 
     if (!appDir && !pagesDir) {
       console.error("Error: Neither 'app' nor 'pages' directory found in root or src directory");

--- a/packages/nextjs/src/generator.ts
+++ b/packages/nextjs/src/generator.ts
@@ -3,26 +3,28 @@ import { createAppScanner } from "./scanner/createAppScanner";
 import { createPagesScanner } from "./scanner/createPagesScanner";
 import { createFileContent } from "./writer/createFileContent";
 import { writeToFile } from "./writer/writeToFile";
+import { UserConfig } from "./types";
 
 type Options = {
   appDir: string;
   pagesDir: string;
-  outDir: string;
+  config: UserConfig;
 };
 
-export async function generateTypes(options: Options) {
+export async function generateTypes({ appDir, pagesDir, config }: Options) {
   try {
-    await fs.mkdir(options.outDir, { recursive: true });
-    const appScanner = createAppScanner({ inputDir: options.appDir, outDir: options.outDir });
-    const pagesScanner = createPagesScanner({ inputDir: options.pagesDir, outDir: options.outDir });
+    const outDir = config.outDir || ".safe-routes";
+    await fs.mkdir(outDir, { recursive: true });
+    const appScanner = createAppScanner({ inputDir: appDir, outDir });
+    const pagesScanner = createPagesScanner({ inputDir: pagesDir, outDir });
 
     const appRoutes = appScanner ? await appScanner() : [];
     const pagesRoutes = pagesScanner ? await pagesScanner() : [];
     const allRoutes = [...appRoutes, ...pagesRoutes];
 
     // generate TypeScript source file
-    const content = createFileContent(allRoutes);
-    await writeToFile(content, `${options.outDir}/index.ts`);
+    const content = createFileContent({ routes: allRoutes, config });
+    await writeToFile(content, `${outDir}/index.ts`);
   } catch (error) {
     console.error("Error generating types:", error);
   }

--- a/packages/nextjs/src/generator.ts
+++ b/packages/nextjs/src/generator.ts
@@ -25,10 +25,6 @@ export async function generateTypes({ appDir, pagesDir, options }: Options) {
     // generate TypeScript source file
     const content = createFileContent({ routes: allRoutes, options });
     await writeToFile(content, `${outDir}/index.ts`);
-    console.log("==================================");
-    console.log("✨ Generating routes types...");
-    console.log("🚀 by @safe-routes/nextjs");
-    console.log("==================================");
   } catch (error) {
     console.error("Error generating types:", error);
   }

--- a/packages/nextjs/src/generator.ts
+++ b/packages/nextjs/src/generator.ts
@@ -3,17 +3,17 @@ import { createAppScanner } from "./scanner/createAppScanner";
 import { createPagesScanner } from "./scanner/createPagesScanner";
 import { createFileContent } from "./writer/createFileContent";
 import { writeToFile } from "./writer/writeToFile";
-import { UserConfig } from "./types";
+import { UserOptions } from "./types";
 
 type Options = {
   appDir: string;
   pagesDir: string;
-  config: UserConfig;
+  options: UserOptions;
 };
 
-export async function generateTypes({ appDir, pagesDir, config }: Options) {
+export async function generateTypes({ appDir, pagesDir, options }: Options) {
   try {
-    const outDir = config.outDir || ".safe-routes";
+    const outDir = options.outDir || ".safe-routes";
     await fs.mkdir(outDir, { recursive: true });
     const appScanner = createAppScanner({ inputDir: appDir, outDir });
     const pagesScanner = createPagesScanner({ inputDir: pagesDir, outDir });
@@ -23,7 +23,7 @@ export async function generateTypes({ appDir, pagesDir, config }: Options) {
     const allRoutes = [...appRoutes, ...pagesRoutes];
 
     // generate TypeScript source file
-    const content = createFileContent({ routes: allRoutes, config });
+    const content = createFileContent({ routes: allRoutes, options });
     await writeToFile(content, `${outDir}/index.ts`);
     console.log("==================================");
     console.log("✨ Generating routes types...");

--- a/packages/nextjs/src/generator.ts
+++ b/packages/nextjs/src/generator.ts
@@ -25,6 +25,10 @@ export async function generateTypes({ appDir, pagesDir, config }: Options) {
     // generate TypeScript source file
     const content = createFileContent({ routes: allRoutes, config });
     await writeToFile(content, `${outDir}/index.ts`);
+    console.log("==================================");
+    console.log("✨ Generating routes types...");
+    console.log("🚀 by @safe-routes/nextjs");
+    console.log("==================================");
   } catch (error) {
     console.error("Error generating types:", error);
   }

--- a/packages/nextjs/src/tests/globalSetup.ts
+++ b/packages/nextjs/src/tests/globalSetup.ts
@@ -4,6 +4,9 @@ export const setup = async () => {
   await generateTypes({
     appDir: 'src/fixtures/app',
     pagesDir: '',
-    outDir: 'src/tests/.safe-routes'
+    config: {
+      outDir: 'src/tests/.safe-routes',
+      trailingSlash: false,
+    }
   });
 };

--- a/packages/nextjs/src/tests/globalSetup.ts
+++ b/packages/nextjs/src/tests/globalSetup.ts
@@ -4,7 +4,7 @@ export const setup = async () => {
   await generateTypes({
     appDir: 'src/fixtures/app',
     pagesDir: '',
-    config: {
+    options: {
       outDir: 'src/tests/.safe-routes',
       trailingSlash: false,
     }

--- a/packages/nextjs/src/transformer/routes/createRouteDefinition.ts
+++ b/packages/nextjs/src/transformer/routes/createRouteDefinition.ts
@@ -1,13 +1,16 @@
-import { RouteFunctionDefinition } from "../../types";
+import { FileContentOption, RouteFunctionDefinition } from "../../types";
 import { convertPathToParamFormat } from "./createRoutePaths";
 
-export const createRouteDefinition = (
-  route: RouteFunctionDefinition,
-) => {
+type CreateRouteDefinitionOption = {
+  route: RouteFunctionDefinition;
+  config: FileContentOption["config"];
+};
+
+export const createRouteDefinition = ({ route, config }: CreateRouteDefinitionOption) => {
   const path =
     route.routeSegments.length === 0
       ? `"/"`
-      : `"/${convertPathToParamFormat(route.routeSegments)}/"`;
+      : `"/${convertPathToParamFormat(route.routeSegments)}${config.trailingSlash ? "/" : ""}"`;
 
   const hasOptionalCatchAll = route.routeSegments.some(
     (s) => s.dynamicType === "optional-catch-all"
@@ -17,7 +20,7 @@ export const createRouteDefinition = (
     const basePath = `"/${route.routeSegments
       .filter(s => s.dynamicType !== "optional-catch-all")
       .map(s => s.rawParamName)
-      .join("/")}/"`;
+      .join("/")}${config.trailingSlash ? "/" : ""}"`;
 
     return `${basePath}: {
   params: {} as Record<string, never>,

--- a/packages/nextjs/src/transformer/routes/createRouteDefinition.ts
+++ b/packages/nextjs/src/transformer/routes/createRouteDefinition.ts
@@ -3,14 +3,14 @@ import { convertPathToParamFormat } from "./createRoutePaths";
 
 type CreateRouteDefinitionOption = {
   route: RouteFunctionDefinition;
-  config: FileContentOption["config"];
+  options: FileContentOption["options"];
 };
 
-export const createRouteDefinition = ({ route, config }: CreateRouteDefinitionOption) => {
+export const createRouteDefinition = ({ route, options }: CreateRouteDefinitionOption) => {
   const path =
     route.routeSegments.length === 0
       ? `"/"`
-      : `"/${convertPathToParamFormat(route.routeSegments)}${config.trailingSlash ? "/" : ""}"`;
+      : `"/${convertPathToParamFormat(route.routeSegments)}${options.trailingSlash ? "/" : ""}"`;
 
   const hasOptionalCatchAll = route.routeSegments.some(
     (s) => s.dynamicType === "optional-catch-all"
@@ -20,7 +20,7 @@ export const createRouteDefinition = ({ route, config }: CreateRouteDefinitionOp
     const basePath = `"/${route.routeSegments
       .filter(s => s.dynamicType !== "optional-catch-all")
       .map(s => s.rawParamName)
-      .join("/")}${config.trailingSlash ? "/" : ""}"`;
+      .join("/")}${options.trailingSlash ? "/" : ""}"`;
 
     return `${basePath}: {
   params: {} as Record<string, never>,

--- a/packages/nextjs/src/transformer/routes/createRoutePaths.ts
+++ b/packages/nextjs/src/transformer/routes/createRoutePaths.ts
@@ -10,18 +10,18 @@ export const convertPathToParamFormat = (segments: RouteSegment[]) => {
     .join("/");
 };
 
-export const createRoutePaths = (options: FileContentOption) => {
-  return `${options.routes
+export const createRoutePaths = ({ routes, options }: FileContentOption) => {
+  return `${routes
     .map((route) => {
       const path = route.routeSegments.length === 0
         ? "/"
-        : `/${convertPathToParamFormat(route.routeSegments)}${options.config.trailingSlash ? "/" : ""}`;
+        : `/${convertPathToParamFormat(route.routeSegments)}${options.trailingSlash ? "/" : ""}`;
 
       if (route.routeSegments.some((s) => s.dynamicType === "optional-catch-all")) {
         const basePath = `/${route.routeSegments
           .filter(s => s.dynamicType !== "optional-catch-all")
           .map(s => s.rawParamName)
-          .join("/")}${options.config.trailingSlash ? "/" : ""}`;
+          .join("/")}${options.trailingSlash ? "/" : ""}`;
 
         return `"${path}" | "${basePath}"`;
       }

--- a/packages/nextjs/src/transformer/routes/createRoutePaths.ts
+++ b/packages/nextjs/src/transformer/routes/createRoutePaths.ts
@@ -1,4 +1,4 @@
-import { RouteFunctionDefinition, RouteSegment } from "../../types";
+import { FileContentOption, RouteSegment } from "../../types";
 
 export const convertPathToParamFormat = (segments: RouteSegment[]) => {
   if (segments.length === 0) return "";
@@ -10,18 +10,18 @@ export const convertPathToParamFormat = (segments: RouteSegment[]) => {
     .join("/");
 };
 
-export const createRoutePaths = (routes: RouteFunctionDefinition[]) => {
-  return `${routes
+export const createRoutePaths = (options: FileContentOption) => {
+  return `${options.routes
     .map((route) => {
       const path = route.routeSegments.length === 0
         ? "/"
-        : `/${convertPathToParamFormat(route.routeSegments)}/`;
+        : `/${convertPathToParamFormat(route.routeSegments)}${options.config.trailingSlash ? "/" : ""}`;
 
       if (route.routeSegments.some((s) => s.dynamicType === "optional-catch-all")) {
         const basePath = `/${route.routeSegments
           .filter(s => s.dynamicType !== "optional-catch-all")
           .map(s => s.rawParamName)
-          .join("/")}/`;
+          .join("/")}${options.config.trailingSlash ? "/" : ""}`;
 
         return `"${path}" | "${basePath}"`;
       }

--- a/packages/nextjs/src/transformer/transformFunctionExports.ts
+++ b/packages/nextjs/src/transformer/transformFunctionExports.ts
@@ -3,9 +3,9 @@ import { createRouteDefinition } from "./routes/createRouteDefinition";
 import { createRoutePaths } from "./routes/createRoutePaths";
 import { createSafeRoute } from "./routes/createSafeRoute";
 
-export const transformFunctionExports = (options: FileContentOption) => {
-  const routePaths = createRoutePaths(options);
-  const routeDefinitions = options.routes.map((route) => createRouteDefinition({ route, config: options.config }));
+export const transformFunctionExports = ({ routes, options }: FileContentOption) => {
+  const routePaths = createRoutePaths({ routes, options });
+  const routeDefinitions = routes.map((route) => createRouteDefinition({ route, options }));
   const safeRoute = createSafeRoute();
 
   return `

--- a/packages/nextjs/src/transformer/transformFunctionExports.ts
+++ b/packages/nextjs/src/transformer/transformFunctionExports.ts
@@ -1,11 +1,11 @@
-import { RouteFunctionDefinition } from "../types";
+import { FileContentOption } from "../types";
 import { createRouteDefinition } from "./routes/createRouteDefinition";
 import { createRoutePaths } from "./routes/createRoutePaths";
 import { createSafeRoute } from "./routes/createSafeRoute";
 
-export const transformFunctionExports = (routes: RouteFunctionDefinition[]) => {
-  const routePaths = createRoutePaths(routes);
-  const routeDefinitions = routes.map((route) => createRouteDefinition(route));
+export const transformFunctionExports = (options: FileContentOption) => {
+  const routePaths = createRoutePaths(options);
+  const routeDefinitions = options.routes.map((route) => createRouteDefinition({ route, config: options.config }));
   const safeRoute = createSafeRoute();
 
   return `

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -1,1 +1,14 @@
+import { RouteFunctionDefinition } from "./route";
+
 export type { DynamicRouteType, RouteFunctionDefinition, RouteSegment } from "./route";
+
+export type FileContentOption = {
+  routes: RouteFunctionDefinition[];
+  config: UserConfig;
+};
+
+export type UserConfig = {
+  trailingSlash: boolean;
+  outDir?: string;
+  watch?: boolean;
+};

--- a/packages/nextjs/src/types/index.ts
+++ b/packages/nextjs/src/types/index.ts
@@ -4,10 +4,10 @@ export type { DynamicRouteType, RouteFunctionDefinition, RouteSegment } from "./
 
 export type FileContentOption = {
   routes: RouteFunctionDefinition[];
-  config: UserConfig;
+  options: UserOptions;
 };
 
-export type UserConfig = {
+export type UserOptions = {
   trailingSlash: boolean;
   outDir?: string;
   watch?: boolean;

--- a/packages/nextjs/src/writer/createFileContent.ts
+++ b/packages/nextjs/src/writer/createFileContent.ts
@@ -1,10 +1,10 @@
 import { transformFunctionExports } from "../transformer/transformFunctionExports";
 import { transformFunctionShared } from "../transformer/transformFunctionShared";
-import { RouteFunctionDefinition } from "../types";
+import { FileContentOption } from "../types";
 
-export const createFileContent = (routes: RouteFunctionDefinition[]): string => {
+export const createFileContent = ({ routes, config }: FileContentOption): string => {
   const shared = transformFunctionShared();
-  const exports = transformFunctionExports(routes);
+  const exports = transformFunctionExports({ routes, config });
 
   return `${shared}\n${exports}`;
 };

--- a/packages/nextjs/src/writer/createFileContent.ts
+++ b/packages/nextjs/src/writer/createFileContent.ts
@@ -2,9 +2,9 @@ import { transformFunctionExports } from "../transformer/transformFunctionExport
 import { transformFunctionShared } from "../transformer/transformFunctionShared";
 import { FileContentOption } from "../types";
 
-export const createFileContent = ({ routes, config }: FileContentOption): string => {
+export const createFileContent = ({ routes, options }: FileContentOption): string => {
   const shared = transformFunctionShared();
-  const exports = transformFunctionExports({ routes, config });
+  const exports = transformFunctionExports({ routes, options });
 
   return `${shared}\n${exports}`;
 };


### PR DESCRIPTION
- Introduce `trailingSlash` configuration option in CLI and generator
- Update type definitions to support new configuration
- Modify route path generation to respect trailing slash setting
- Enhance CLI with `--no-trailing-slash` flag to disable trailing slashes
- Refactor generator and transformer functions to use new configuration